### PR TITLE
More upstream compatibility:

### DIFF
--- a/console.inc
+++ b/console.inc
@@ -1,0 +1,19 @@
+/* String functions
+ *
+ * (c) Copyright 1998-2011, ITB CompuPhase
+ * This file is provided as is (no warranties).
+ */
+#if defined _console_included
+  #endinput
+#endif
+#define _console_included
+#pragma library Console
+
+// Don't define "printf" twice.
+#tryinclude <a_samp>
+#if defined _samp_included
+	#endinput
+#endif
+
+native print(const string[]);
+native printf(const format[], {Float,_}:...);

--- a/default.inc
+++ b/default.inc
@@ -1,0 +1,2 @@
+#include <core>
+#include <console>

--- a/string.inc
+++ b/string.inc
@@ -13,6 +13,8 @@ native strlen(const string[]);
 native strpack(dest[], const source[], maxlength=sizeof dest);
 native strunpack(dest[], const source[], maxlength=sizeof dest);
 native strcat(dest[], const source[], maxlength=sizeof dest);
+stock strcopy(dest[], const source[], maxlength=sizeof dest)
+	return strcat((dest[0] = EOS, dest), source, maxlength);
 
 native strmid(dest[], const source[], start, end, maxlength=sizeof dest);
 native bool: strins(string[], const substr[], pos, maxlength=sizeof string);
@@ -25,6 +27,12 @@ native strval(const string[]);
 native valstr(dest[], value, bool:pack=false);
 native bool: ispacked(const string[]);
 
+native format(dest[], size=sizeof dest, const format[], {Float,_}:...);
+#define strformat(%0,%1,%2,%3) format(%0,%1,%3)
+
 native uudecode(dest[], const source[], maxlength=sizeof dest);
 native uuencode(dest[], const source[], numbytes, maxlength=sizeof dest);
 native memcpy(dest[], const source[], index=0, numbytes, maxlength=sizeof dest);
+
+stock bool: strequal(const string1[], const string2[], bool:ignorecase=false, length=cellmax)
+	return strcmp(string1, string2, ignorecase, length) == 0;


### PR DESCRIPTION
Added `strformat`, `strcopy`, and `strequal` to string.inc.
Added console.inc with `print` and `printf`.
Added default.inc including core.inc and console.inc.
Made console.inc try include a_samp.inc so that `print` and `printf` aren't defined twice if it exists.

These changes are a small attempt to improve code compatibility with: https://github.com/compuphase/pawn/tree/master/include (the original PAWN repository with more functions).  One thing discussed was the fact that `print` and `printf` are quite core functions, but are defined in a_samp.inc with game API functions.  The upstream code puts them in console.inc, so this does too.

TODO:

Maybe try backport even more of the newer functions like the `cfg` and console `get` ones.