### PR TITLE
add documentation

### DIFF
--- a/console.inc
+++ b/console.inc
@@ -15,5 +15,32 @@
 	#endinput
 #endif
 
+/// <summary>Prints a string to the server console (not in-game chat) and logs (server_log.txt).</summary>
+/// <param name="string">The string to print</param>
+/// <seealso name="printf"/>
 native print(const string[]);
+
+/// <summary>Outputs a formatted string on the console (the server window, not the in-game chat).</summary>
+/// <param name="format">The format string</param>
+/// <param name="">Indefinite number of arguments of any tag</param>
+/// <seealso name="print"/>
+/// <seealso name="format"/>
+/// <remarks>The format string or its output should not exceed 1024 characters. Anything beyond that length can lead to a server to crash.</remarks>
+/// <remarks>This function doesn't support <a href="#strpack">packed</a> strings.</remarks>
+/// <remarks>
+///   <b>Format Specifiers:</b><p/>
+///   <ul>
+///     <li><b><c>%i</c></b> - integer (whole number)</li>
+///     <li><b><c>%d</c></b> - integer (whole number).</li>
+///     <li><b><c>%s</c></b> - string</li>
+///     <li><b><c>%f</c></b> - floating-point number (Float: tag)</li>
+///     <li><b><c>%c</c></b> - ASCII character</li>
+///     <li><b><c>%x</c></b> - hexadecimal number</li>
+///     <li><b><c>%b</c></b> - binary number</li>
+///     <li><b><c>%%</c></b> - literal <b><c>%</c></b></li>
+///     <li><b><c>%q</c></b> - escape a text for SQLite. (Added in <b>0.3.7 R2</b>)</li>
+///   </ul>
+/// </remarks>
+/// <remarks>The values for the placeholders follow in the exact same order as parameters in the call. For example, <b><c>"I am %i years old"</c></b> - the <b><c>%i</c></b> will be replaced with an Integer variable, which is the person's age.</remarks>
+/// <remarks>You may optionally put a number between the <b><c>%</c></b> and the letter of the placeholder code. This number indicates the field width; if the size of the parameter to print at the position of the placeholder is smaller than the field width, the field is expanded with spaces. To cut the number of decimal places beeing shown of a float, you can add <b><c>.&lt;max number&gt;</c></b> between the <b><c>%</c></b> and the <b><c>f</c></b>. (example: <b><c>%.2f</c></b>)</remarks>
 native printf(const format[], {Float,_}:...);

--- a/core.inc
+++ b/core.inc
@@ -9,26 +9,127 @@
 #define _core_included
 #pragma library Core
 
+
+/// <summary>Returns the amount of memory available for the heap/stack in bytes.</summary>
+/// <remarks>In absence of recursion, the pawn parser can also give an estimate of the required stack/heap space.</remarks>
+/// <returns>The free space on the heap in bytes. The stack and the heap occupy a shared memory area, so this value indicates the number of bytes that is left for either the stack or the heap.</returns>
 native heapspace();
 
+/// <summary>This function returns the ID of a public function by its name.</summary>
+/// <param name="name">The name of the public function to get the ID of</param>
+/// <seealso name="CallLocalFunction"/>
+/// <seealso name="CallRemoteFunction"/>
+/// <returns>The ID of the function (IDs start at <b><c>0</c></b>). <b><c>-1</c></b> if the function doesn't exist.</returns>
 native funcidx(const name[]);
 
+/// <summary>Get the number of arguments passed to a function.</summary>
+/// <seealso name="getarg"/>
+/// <seealso name="setarg"/>
+/// <returns>The number of arguments passed.</returns>
 native numargs();
+
+/// <summary>Get an argument that was passed to a function.</summary>
+/// <param name="arg">The argument sequence number. Use <b><c>0</c></b> for first argument</param>
+/// <param name="index">The index (in case the argument is an array) (optional=<b><c>0</c></b>)</param>
+/// <seealso name="numargs"/>
+/// <seealso name="setarg"/>
+/// <returns>The value of the argument.</returns>
 native getarg(arg, index=0);
+
+/// <summary>Set an argument that was passed to a function.</summary>
+/// <param name="arg">The argument sequence number. Use <b><c>0</c></b> for first argument</param>
+/// <param name="index">The index (if the argument is an array) (optional=<b><c>0</c></b>)</param>
+/// <param name="value">The value to set the argument to</param>
+/// <seealso name="getarg"/>
+/// <seealso name="numargs"/>
+/// <returns><b><c>1</c></b> on success and <b><c>0</c></b> if the argument or the index are invalid.</returns>
 native setarg(arg, index=0, value);
 
+/// <summary>This function changes a single character to lowercase.</summary>
+/// <param name="c">The character to change to lowercase</param>
+/// <remarks>Support for accented characters is platform-dependent.</remarks>
+/// <returns>The lower case variant of the input character, if one exists, or the unchanged character code of c if the letter c has no lower case equivalent.</returns>
 native tolower(c);
+
+/// <summary>This function changes a single character to uppercase.</summary>
+/// <param name="c">The character to change to uppercase</param>
+/// <remarks>Support for accented characters is platform-dependent.</remarks>
+/// <returns>The upper case variant of the input character, if one exists, or the unchanged character code of c if the letter c has no upper case equivalent.</returns>
 native toupper(c);
+
+/// <summary>Swap bytes in a cell</summary>
+/// <param name="c">The value for which to swap the bytes.</param>
+/// <returns>A value where the bytes are swapped (the lowest byte becomes the highest byte)</returns>
 native swapchars(c);
 
+/// <summary>Get a pseudo-random number.</summary>
+/// <param name="max">The range of values (from <b><c>0</c></b> to <b><c>max-1</c></b>) that can be returned</param>
+/// <remarks>Using a value smaller than <b><c>1</c></b> gives weird values.</remarks>
+/// <remarks>The standard random number generator of pawn is likely a linear congruential pseudo-random number generator with a range and a period of 2^31. Linear congruential pseudo-random number generators suffer from serial correlation (especially in the low bits) and it is unsuitable for applications that require high-quality random numbers.</remarks>
+/// <returns>A random number ranging from <b><c>0</c></b> to <b><c>max-1</c></b>.</returns>
 native random(max);
 
+/// <summary>Return the lowest of two numbers</summary>
+/// <param name="value1">The two values for which to find the lowest number</param>
+/// <param name="value2">The two values for which to find the lowest number</param>
+/// <seealso name="clamp"/>
+/// <seealso name="max"/>
+/// <returns>The lower value of value1 and value2</returns>
 native min(value1, value2);
+
+/// <summary>Return the highest of two numbers</summary>
+/// <param name="value1">The two values for which to find the highest number</param>
+/// <param name="value2">The two values for which to find the highest number</param>
+/// <seealso name="clamp"/>
+/// <seealso name="min"/>
+/// <returns>The higher value of value1 and value2</returns>
 native max(value1, value2);
+
+/// <summary>Force a value to be inside a range.</summary>
+/// <param name="value">The value to force in a range</param>
+/// <param name="min">The low bound of the range (optional=<b><c>cellmin</c></b>)</param>
+/// <param name="max">The high bound of the range (optional=<b><c>cellmax</c></b>)</param>
+/// <returns>value, if it is in the range min–max, min, if value is lower than min or max, if value is higher than max.</returns>
 native clamp(value, min=cellmin, max=cellmax);
 
+/// <summary>Get a specific property from the memory, the string is returned as a packed string!.</summary>
+/// <param name="id">The <a href="http://en.wikipedia.org/wiki/Virtual_machine">virtual machine</a> to use, you should keep this zero (optional=<b><c>0</c></b>)</param>
+/// <param name="name">The property's name, you should keep this "" (optional=<b><c>""</c></b>)</param>
+/// <param name="value">The property's unique ID, Use the hash-function to calculate it from a string (optional=<b><c>cellmin</c></b>)</param>
+/// <param name="string">The variable to store the result in, passed by reference (optional=<b><c>""</c></b>)</param>
+/// <seealso name="Setproperty"/>
+/// <seealso name="Deleteproperty"/>
+/// <seealso name="Existproperty"/>
+/// <returns>The value of a property when the name is passed in; fills in the string argument when the value is passed in. If the property does not exist, this function returns zero.</returns>
 native getproperty(id=0, const name[]="", value=cellmin, string[]="");
+
+/// <summary>Add a new property or change an existing property.</summary>
+/// <param name="id">The virtual machine to use, you should keep this zero (optional=<b><c>0</c></b>)</param>
+/// <param name="name">Used in combination with value when storing integers; don't use this if you want to store a string(optional=<b><c>""</c></b>)</param>
+/// <param name="value">The integer value to store or the property's unique ID if storing a string. Use the hash-function to calculate it from a string (optional=<b><c>cellmin</c></b>)</param>
+/// <param name="string">The value of the property, as a string. Don't use this if you want to store an integer (optional=<b><c>""</c></b>)</param>
+/// <seealso name="Getproperty"/>
+/// <seealso name="Deleteproperty"/>
+/// <seealso name="Existproperty"/>
 native setproperty(id=0, const name[]="", value=cellmin, const string[]="");
+
+/// <summary>Delete an earlier set property (<a href="#setproperty">setproperty</a>).</summary>
+/// <param name="id">The <a href="http://en.wikipedia.org/wiki/Virtual_machine">virtual machine</a> to use. You should keep this as zero (optional=<b><c>0</c></b>)</param>
+/// <param name="name">The property's name, you should keep this blank (optional=<b><c>""</c></b>)</param>
+/// <param name="value">The property's unique ID. Use the hash-function to calculate it from a string (optional=<b><c>cellmin</c></b>)</param>
+/// <seealso name="Setproperty"/>
+/// <seealso name="Getproperty"/>
+/// <seealso name="Existproperty"/>
+/// <returns>The value of the property. If the property does not exist, the function returns <b><c>0</c></b>.</returns>
 native deleteproperty(id=0, const name[]="", value=cellmin);
+
+/// <summary>Check if a property exist.</summary>
+/// <param name="id">The <a href="http://en.wikipedia.org/wiki/Virtual_machine">virtual machine</a> to use, you should keep this zero (optional=<b><c>0</c></b>)</param>
+/// <param name="name">The property's name, you should keep this (optional=<b><c>""</c></b>)</param>
+/// <param name="value">The property's unique ID. Use the hash-function to calculate it from a string (optional=<b><c>cellmin</c></b>)</param>
+/// <seealso name="Setproperty"/>
+/// <seealso name="Getproperty"/>
+/// <seealso name="Deleteproperty"/>
+/// <returns><b><c>1</c></b> if the property exists and <b><c>0</c></b> otherwise.</returns>
 native existproperty(id=0, const name[]="", value=cellmin);
 

--- a/datagram.inc
+++ b/datagram.inc
@@ -9,10 +9,54 @@
 #define _datagram_included
 #pragma library DGram
 
+/// <summary>Sends a packet containing a string.</summary>
+/// <param name="message">The buffer that contains the string to send. If this is an unpacked string, it will be UTF-8 encoded before being transferred.</param>
+/// <param name="destination">The IP address and port number to which the packet must be sent. If absent or an empty string, this function will broadcast the packet and use the default port number 9930 (optional=<c><b>""</b></c>)</param>
+/// <seealso name="@receivestring"/>
+/// <seealso name="sendpacket"/>
+/// <remarks>This function does not work in the current SA:MP version!</remarks>
+/// <returns><b><c>1</c></b> on success, <b><c>0</c></b> on failure.</returns>
 native sendstring(const message[], const destination[]="");
+
+/// <summary>Sends a packet.</summary>
+/// <param name="packet">The buffer that contains the packet to send.</param>
+/// <param name="destination">The IP address and port number to which the packet must be sent. If absent or an empty string, this function will broadcast the packet and use the default port number 9930 (optional=<c><b>""</b></c>)</param>
+/// <seealso name="@receivepacket"/>
+/// <seealso name="sendstring"/>
+/// <remarks>This function does not work in the current SA:MP version!</remarks>
+/// <returns><b><c>1</c></b> on success, <b><c>0</c></b> on failure.</returns>
 native sendpacket(const packet[], size, const destination[]="");
 
+
+/// <summary>Sets up the port number to listen at.</summary>
+/// <param name="port">The number of the port to listen at. This must be a value between <c><b>1</b></c> and <c><b>65535</b></c>, but you should probably avoid to use any of the reserved port numbers.</param>
+/// <seealso name="@receivestring"/>
+/// <seealso name="sendstring"/>
+/// <remarks>You must call this function <b>before</b> receiving the first packet. In other words, you should set up a port in main.</remarks>
+/// <remarks>If no port number has been explicitily chosen, the module will listen at port <c><b>9930</b></c>.</remarks>
+/// <remarks>This function does not work in the current SA:MP version!</remarks>
+/// <returns>This function always returns <b><c>0</c></b>.</returns>
 native listenport(port);
 
+
+/// <summary>A packed was received.</summary>
+/// <param name="message">Contains the message (a zero-terminated string) that was received.</param>
+/// <param name="source">Contains the IP address and the port number of the sender of this packet.</param>
+/// <seealso name="@receivepacket"/>
+/// <seealso name="sendstring"/>
+/// <remarks>The string is in unpacked format if the original packet contained a string in UTF-8 format. Note that messages in the ASCII character set are also UTF-8 compliant.</remarks>
+/// <remarks>This function does not work in the current SA:MP version!</remarks>
+/// <returns>The return value of this function is currently ignored.</returns>
 forward @receivestring(const message[], const source[]);
+
+/// <summary>A packed was received.</summary>
+/// <param name="packet">Contains the packet that was received.</param>
+/// <param name="size">Contains the number of <b>bytes</b> (not cells) that are in the packet</param>
+/// <param name="source">Contains the IP address and the port number of the sender of this packet.</param>
+/// <seealso name="@receivestring"/>
+/// <seealso name="sendpacket"/>
+/// <remarks>You must call this function before receiving the first packet. In other words, you should set up a port in main.</remarks>
+/// <remarks>If no port number has been explicitily chosen, the module will listen at port <c><b>9930</b></c>.</remarks>
+/// <remarks>This function does not work in the current SA:MP version!</remarks>
+/// <returns>The return value of this function is currently ignored.</returns>
 forward @receivepacket(const packet[], size, const source[]);

--- a/file.inc
+++ b/file.inc
@@ -144,7 +144,7 @@ native fexist(const pattern[]);
 
 /// <summary>Find a filename matching a pattern.</summary>
 /// <param name="name">The string to hold the result in, returned as a packed string</param>
-/// <param name="const pattern">The pattern that should be matched. May contain wildcards</param>
+/// <param name="pattern">The pattern that should be matched. May contain wildcards</param>
 /// <param name="index">The number of the file, in case there are multiple matches (optional=<b><c>0</c></b>)</param>
 /// <param name="size">The maximum size of parameter name (optional=<b><c>sizeof name</c></b>)</param>
 /// <remarks>This function does not work in the current SA:MP version!</remarks>

--- a/file.inc
+++ b/file.inc
@@ -26,19 +26,127 @@ enum seek_whence
 
 const EOF = -1;
 
+/// <summary>Open a file (to read from or write to).</summary>
+/// <param name="name">The path to the file to open (if just a filename is specified, it will open the file with the name specified in the 'scriptfiles' folder)</param>
+/// <param name="mode">The mode to open the file with, see below (optional=<b><c>io_readwrite</c></b>)</param>
+/// <remarks>This function can't access files outside the 'scriptfiles' folder!</remarks>
+/// <remarks>If you use <a href="#io_read">io_read</a> and the file doesn't exist, it will return a <b><c>NULL</c></b> reference. Using <b>invalid references</b> on file functions will <b>crash</b> your server!</remarks>
+/// <remarks>
+///   <b>Modes:</b><p/>
+///   <ul>
+///     <li><b><c>io_read</c></b> - reads from the file.</li>
+///     <li><b><c>io_write</c></b> - write in the file, or create the file if it does not exist. Erases all existing contents.</li>
+///     <li><b><c>io_readwrite</c></b> - reads the file or creates it if it doesn't already exist.</li>
+///     <li><b><c>io_append</c></b> - appends (adds) to file, write-only. If the file does not exist, it is created.</li>
+///   </ul>
+/// </remarks>
+/// <returns>Returns the file handle. This handle is used for reading and writing. <b><c>0</c></b> if failed to open file.</returns>
 native File:fopen(const name[], filemode: mode = io_readwrite);
+
+/// <summary>Closes a file. Files should always be closed when the script no longer needs them (after reading/writing).</summary>
+/// <param name="handle">The file handle to close. Returned by <a href="#fopen">fopen</a></param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
+/// <returns>
+///   <b><c>true</c></b>: The function executed successfully.<p/>
+///   <b><c>false</c></b>: The function failed to execute. The file could not be closed. It may already be closed.
+/// </returns>
 native bool:fclose(File: handle);
+
+/// <summary>Creates a file in the "tmp", "temp" or root directory with random name for reading and writing. The file is deleted after <a href="#fclose">fclose</a> is used on the file.</summary>
+/// <remarks>This function can crash the server when the right directory isn't created.</remarks>
+/// <returns>The temporary file handle. <b><c>0</c></b> if failed.</returns>
 native File:ftemp();
+
+/// <summary>Delete a file.</summary>
+/// <param name="name">The <b>path</b> of the file to delete. (NOTE: NOT a file handle)</param>
+/// <remarks>The file path must be valid.</remarks>
+/// <remarks>Files that are currently open (<a href="#fopen">fopen</a>) must be closed first (<a href="#fclose">fclose</a>) to be deleted.</remarks>
+/// <returns>
+///   <b><c>true</c></b>: The function executed successfully.<p/>
+///   <b><c>false</c></b>: The function failed to execute. The file doesn't exist, or you don't have permission to delete it.
+/// </returns>
 native bool:fremove(const name[]);
 
+/// <summary>Write text into a file.</summary>
+/// <param name="handle">The handle of the file to write to (returned by <a href="#fopen">fopen</a>)</param>
+/// <param name="string">The string of text to write in to the file</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
+/// <remarks>This functions writes to the file in UTF-8, which does not support some localized language symbols.</remarks>
+/// <remarks>This function doesn't support <a href="#strpack">packed strings</a>.</remarks>
+/// <returns>The length of the written string as an integer.</returns>
 native fwrite(File: handle, const string[]);
+
+/// <summary>Read a single line from a file.</summary>
+/// <param name="handle">The handle of the file to read from (returned by <a href="#fopen">fopen</a>)</param>
+/// <param name="string">A string array to store the read text in, passed by reference</param>
+/// <param name="size">The number of bytes to read (optional=<b><c>sizeof string</c></b>)</param>
+/// <param name="pack">Should the string be packed? (optional=<b><c>false</c></b>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
+/// <returns>The length of <b>string</b> (the read text) as an integer.</returns>
 native fread(File: handle, string[], size = sizeof string, bool: pack = false);
+
+/// <summary>Write one character to a file.</summary>
+/// <param name="handle">The File handle to use, earlier opened by <a href="#fopen">fopen</a></param>
+/// <param name="value">The character to write into the file</param>
+/// <param name="utf8">If true, write in UTF8 mode, otherwise in extended ASCII (optional=<b><c>true</c></b>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
 native bool:fputchar(File: handle, value, bool: utf8 = true);
+
+/// <summary>Reads a single character from a file.</summary>
+/// <param name="handle">The file handle to use; returned by <a href="#fopen">fopen</a></param>
+/// <param name="value">This parameter has no use, just keep it "0"</param>
+/// <param name="utf8">If true, read a character as UTF-8, otherwise as extended ASCII (optional=<b><c>true</c></b>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
+/// <returns>If succeed, it returns the extended ASCII or UTF-8 value of the character at the current position in the file, otherwise EOF (end of file).</returns>
 native fgetchar(File: handle, value, bool: utf8 = true);
+
+/// <summary>Write data to a file in binary format, while ignoring line brakes and encoding.</summary>
+/// <param name="handle">The File handle to use, opened by fopen()</param>
+/// <param name="buffer">The data to write to the file</param>
+/// <param name="size">The number of cells to write (optional=<b><c>sizeof buffer</c></b>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
 native fblockwrite(File: handle, const buffer[], size = sizeof buffer);
+
+/// <summary>This function allows you to read data from a file, without encoding and line terminators.</summary>
+/// <param name="handle">File handle to use, opened by <a href="#fopen">fopen</a></param>
+/// <param name="buffer">The buffer to save the read data in</param>
+/// <param name="size">The number of cells to read (optional=<b><c>sizeof buffer</c></b>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
+/// <returns>The number of cells read. <b><c>0</c></b> if the file end has been reached.</returns>
 native fblockread(File: handle, buffer[], size = sizeof buffer);
 
+/// <summary>Change the current position in the file. You can either seek forward or backward through the file.</summary>
+/// <param name="handle">The file handle to use. Returned by <a href="#fopen">fopen</a></param>
+/// <param name="position">The new position in the file, relative to the parameter whence (see below) (optional=<b><c>0</c></b>)</param>
+/// <param name="whence">The starting position to which parameter position relates (optional=<b><c>seek_start</c></b>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
+/// <remarks>
+///   <b>Whences:</b><p/>
+///   <ul>
+///     <li><b><c>seek_start</c></b> - set the file position relative to the start of the file (the position parameter must be positive).</li>
+///     <li><b><c>seek_current</c></b> - set the file position relative to the current file position: the position parameter is added to the current position.</li>
+///     <li><b><c>seek_end</c></b> - set the file position relative to the end of the file (parameter position must be zero or negative).</li>
+///   </ul>
+/// </remarks>
+/// <returns>The new position; relative to the start of the file.</returns>
 native fseek(File: handle, position = 0, seek_whence: whence = seek_start);
+
+/// <summary>Returns the length of a file.</summary>
+/// <param name="handle">The file handle returned by <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a></param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
+/// <returns>The length of a file, in bytes.</returns>
 native flength(File: handle);
+
+/// <summary>Checks if a specific file exists in the <b><c>/scriptfiles</c></b> directory.</summary>
+/// <param name="pattern">The name of the file, optionally containing wild-cards characters</param>
+/// <returns>The number of files that match the pattern.</returns>
 native fexist(const pattern[]);
+
+/// <summary>Find a filename matching a pattern.</summary>
+/// <param name="name">The string to hold the result in, returned as a packed string</param>
+/// <param name="const pattern">The pattern that should be matched. May contain wildcards</param>
+/// <param name="index">The number of the file, in case there are multiple matches (optional=<b><c>0</c></b>)</param>
+/// <param name="size">The maximum size of parameter name (optional=<b><c>sizeof name</c></b>)</param>
+/// <remarks>This function does not work in the current SA:MP version!</remarks>
+/// <returns><b><c>true</c></b> on success, <b><c>false</c></b> on failure.</returns>
 native bool:fmatch(name[], const pattern[], index = 0, size = sizeof name);

--- a/float.inc
+++ b/float.inc
@@ -27,65 +27,166 @@ enum anglemode {
   grades
 }
 
-/**************************************************/
-/* Convert an integer into a floating point value */
+/// <summary>Converts an integer into a float.</summary>
+/// <param name="value">Integer value to convert to a float</param>
+/// <seealso name="floatround"/>
+/// <seealso name="floatstr"/>
+/// <returns>The given integer as a float.</returns>
 native Float:float(value);
 
-/**************************************************/
-/* Convert a string into a floating point value */
+/// <summary>Converts a string to a float.</summary>
+/// <param name="string">The string to convert into a float</param>
+/// <seealso name="floatround"/>
+/// <seealso name="float"/>
+/// <returns>The requested float value.</returns>
 native Float:floatstr(const string[]);
 
-/**************************************************/
-/* Multiple two floats together */
+/// <summary>Multiplies two floats with each other.</summary>
+/// <param name="oper1">First Float</param>
+/// <param name="oper2">Second Float, the first one gets multiplied with</param>
+/// <seealso name="Floatadd"/>
+/// <seealso name="Floatsub"/>
+/// <seealso name="Floatdiv"/>
+/// <returns>The product of the two given floats.</returns>
 native Float:floatmul(Float:oper1, Float:oper2);
 
-/**************************************************/
-/* Divide the dividend float by the divisor float */
+/// <summary>Divide one float by another one. Redundant as the division operator (/) does the same thing.</summary>
+/// <param name="dividend">First float</param>
+/// <param name="divisor">Second float (dividates the first float.)</param>
+/// <seealso name="floatadd"/>
+/// <seealso name="floatsub"/>
+/// <seealso name="floatmul"/>
+/// <returns>The quotient of the two given floats.</returns>
 native Float:floatdiv(Float:dividend, Float:divisor);
 
-/**************************************************/
-/* Add two floats together */
+/// <summary>Adds two floats together. This function is redundant as the standard operator (+) does the same thing.</summary>
+/// <param name="oper1">First float</param>
+/// <param name="oper2">Second float</param>
+/// <seealso name="Floatsub"/>
+/// <seealso name="Floatmul"/>
+/// <seealso name="Floatdiv"/>
+/// <returns>The sum of the two given floats.</returns>
 native Float:floatadd(Float:oper1, Float:oper2);
 
-/**************************************************/
-/* Subtract oper2 float from oper1 float */
+/// <summary>Subtracts one float from another one. Note that this function has no real use, as one can simply use the standard operator (-) instead.</summary>
+/// <param name="oper1">First Float</param>
+/// <param name="oper2">Second Float (gets subtracted from the first float.)</param>
+/// <seealso name="Floatadd"/>
+/// <seealso name="Floatmul"/>
+/// <seealso name="Floatdiv"/>
+/// <returns>The difference of the two given floats.</returns>
 native Float:floatsub(Float:oper1, Float:oper2);
 
-/**************************************************/
-/* Return the fractional part of a float */
+/// <summary>Get the fractional part of a float. This means the value of the numbers after the decimal point.</summary>
+/// <param name="value">The float to get the fractional part of</param>
+/// <seealso name="floatround"/>
+/// <returns>The fractional part of the float, as a float value.</returns>
 native Float:floatfract(Float:value);
 
-/**************************************************/
-/* Round a float into a integer value */
+/// <summary>Round a floating point number to an integer value.</summary>
+/// <param name="value">The value to round</param>
+/// <param name="method">The floatround method to use (optional=<b><c>floatround_round</c></b>)</param>
+/// <seealso name="float"/>
+/// <seealso name="floatstr"/>
+/// <remarks>
+///   <b>Rounding methods:</b><p/>
+///   <ul>
+///     <li><b><c>floatround_round</c></b> - round to the nearest integer. A fractional part of exactly 0.5 rounds upwards (this is the default).</li>
+///     <li><b><c>floatround_floor</c></b> - round downwards.</li>
+///     <li><b><c>floatround_ceil</c></b> - round upwards.</li>
+///     <li><b><c>floatround_tozero</c></b> - round downwards for positive values and upwards for negative values ("truncate").</li>
+///   </ul>
+/// </remarks>
+/// <returns>The rounded value as an integer.</returns>
 native floatround(Float:value, floatround_method:method=floatround_round);
 
-/**************************************************/
-/* Compare two integers. If the two elements are equal, return 0.
-   If the first argument is greater than the second argument, return 1,
-   If the first argument is less than the second argument, return -1. */
+/// <summary>floatcmp can be used to compare float values to each other, to validate the comparison.</summary>
+/// <param name="oper1">The first float value to compare</param>
+/// <param name="oper2">The second float value to compare</param>
+/// <returns><b><c>0</c></b> if value does match, <b><c>1</c></b> if the first value is bigger and <b><c>-1</c></b> if the 2nd value is bigger.</returns>
 native floatcmp(Float:oper1, Float:oper2);
 
-/**************************************************/
-/* Return the square root of the input value, same as floatpower(value, 0.5) */
+/// <summary>Calculates the square root of given value.</summary>
+/// <param name="value">The value to calculate the square root of</param>
+/// <seealso name="floatpower"/>
+/// <seealso name="floatlog"/>
+/// <remarks>This function raises a "domain" error if the input value is negative. You may use <a href="#floatabs">floatabs</a> to get the absolute (positive) value.</remarks>
+/// <returns>The square root of the input value, as a float.</returns>
 native Float:floatsqroot(Float:value);
 
-/**************************************************/
-/* Return the value raised to the power of the exponent */
+/// <summary>Raises the given value to the power of the exponent.</summary>
+/// <param name="value">The value to raise to a power, as a floating-point number</param>
+/// <param name="exponent">The exponent is also a floating-point number. It may be zero or negative</param>
+/// <seealso name="floatsqroot"/>
+/// <seealso name="floatlog"/>
+/// <returns>The result of 'value' to the power of 'exponent'.</returns>
 native Float:floatpower(Float:value, Float:exponent);
 
-/**************************************************/
-/* Return the logarithm */
+/// <summary>This function allows you to get the logarithm of a float value.</summary>
+/// <param name="value">The value of which to get the logarithm</param>
+/// <param name="base">The logarithm base (optional=<b><c>10.0</c></b>)</param>
+/// <seealso name="floatsqroot"/>
+/// <seealso name="floatpower"/>
+/// <returns>The logarithm as a float value.</returns>
 native Float:floatlog(Float:value, Float:base=10.0);
 
-/**************************************************/
-/* Return the sine, cosine or tangent. The input angle may be in radian,
-   degrees or grades. */
+/// <summary>Get the sine from a given angle. The input angle may be in radians, degrees or grades.</summary>
+/// <param name="value">The angle from which to get the sine</param>
+/// <param name="mode">The angle mode (see below) to use, depending on the value entered (optional=<b><c>radian</c></b>)</param>
+/// <seealso name="floattan"/>
+/// <seealso name="floatcos"/>
+/// <remarks>GTA/SA-MP use <b>degrees</b> for angles in most circumstances, for example <a href="#GetPlayerFacingAngle">GetPlayerFacingAngle</a>. Therefore, it is most likely you'll want to use the <b>degrees</b> angle mode, not radians. </remarks>
+/// <remarks>Also note that angles in GTA are counterclockwise; 270° is East and 90° is West. South is still 180° and North still 0°/360°. </remarks>
+/// <remarks>
+///   <b>Angle modes:</b><p/>
+///   <ul>
+///     <li>radian</li>
+///     <li>degrees</li>
+///     <li>grades </li>
+///   </ul>
+/// </remarks>
+/// <returns>The sine of the value entered.</returns>
 native Float:floatsin(Float:value, anglemode:mode=radian);
+
+/// <summary>Get the cosine from a given angle. The input angle may be in radians, degrees or grades.</summary>
+/// <param name="value">The angle from which to get the cosine</param>
+/// <param name="mode">The angle mode (see below) to use, depending on the value entered (optional=<b><c>radian</c></b>)</param>
+/// <seealso name="floatsin"/>
+/// <seealso name="floattan"/>
+/// <remarks>GTA/SA-MP use <b>degrees</b> for angles in most circumstances, for example <a href="#GetPlayerFacingAngle">GetPlayerFacingAngle</a>. Therefore, it is most likely you'll want to use the <b>degrees</b> angle mode, not radians. </remarks>
+/// <remarks>Also note that angles in GTA are counterclockwise; 270° is East and 90° is West. South is still 180° and North still 0°/360°. </remarks>
+/// <remarks>
+///   <b>Angle modes:</b><p/>
+///   <ul>
+///     <li>radian</li>
+///     <li>degrees</li>
+///     <li>grades </li>
+///   </ul>
+/// </remarks>
+/// <returns>The cosine of the value entered.</returns>
 native Float:floatcos(Float:value, anglemode:mode=radian);
+
+/// <summary>Get the tangent from a given angle. The input angle may be in radians, degrees or grades.</summary>
+/// <param name="value">The angle from which to get the tangent</param>
+/// <param name="mode">The angle mode to use, depending on the value entered</param>
+/// <seealso name="floatsin"/>
+/// <seealso name="floatcos"/>
+/// <remarks>GTA/SA-MP use <b>degrees</b> for angles in most circumstances, for example <a href="#GetPlayerFacingAngle">GetPlayerFacingAngle</a>. Therefore, it is most likely you'll want to use the <b>degrees</b> angle mode, not radians. </remarks>
+/// <remarks>Also note that angles in GTA are counterclockwise; 270° is East and 90° is West. South is still 180° and North still 0°/360°. </remarks>
+/// <remarks>
+///   <b>Angle modes:</b><p/>
+///   <ul>
+///     <li>radian</li>
+///     <li>degrees</li>
+///     <li>grades </li>
+///   </ul>
+/// </remarks>
+/// <returns>The tangent from the value entered.</returns>
 native Float:floattan(Float:value, anglemode:mode=radian);
 
-/**************************************************/
-/* Return the absolute value */
+/// <summary>This function returns the absolute value of float.</summary>
+/// <param name="value">The float value to get the absolute value of</param>
+/// <returns>The absolute value of the float (as a float value).</returns>
 native Float:floatabs(Float:value);
 
 

--- a/string.inc
+++ b/string.inc
@@ -9,22 +9,221 @@
 #define _string_included
 #pragma library String
 
+
+/// <summary>Get the length of a string.</summary>
+/// <param name="string">The string to get the length of</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
+/// <returns>The length of the string as an integer.</returns>
 native strlen(const string[]);
+
+/// <summary>Pack a string. Packed strings use 75% less memory.</summary>
+/// <param name="dest">The destination string to save the packed string in, passed by reference</param>
+/// <param name="source">The source, original string</param>
+/// <param name="maxlength">The maximum size to insert (optional=<b><c>sizeof dest</c></b>)</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
+/// <returns>The number of characters packed.</returns>
 native strpack(dest[], const source[], maxlength=sizeof dest);
+
+/// <summary>This function can be used to unpack a string.</summary>
+/// <param name="dest">The destination string to save the unpacked string in, passed by reference</param>
+/// <param name="source">The source, original packed string</param>
+/// <param name="maxlength">The maximum size to insert (optional=<b><c>sizeof dest</c></b>)</param>
+/// <seealso name="ispacked"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
+/// <returns>The number of characters packed.</returns>
 native strunpack(dest[], const source[], maxlength=sizeof dest);
+
+/// <summary>This function concatenates (joins together) two strings into the destination string.</summary>
+/// <param name="dest">The string to store the two concatenated strings in</param>
+/// <param name="source">The source string</param>
+/// <param name="maxlength">The maximum length of the destination (optional=<b><c>sizeof dest</c></b>)</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strval"/>
+/// <returns>The length of the new destination string.</returns>
 native strcat(dest[], const source[], maxlength=sizeof dest);
+
+/// <summary>Copies a string into the destination string.</summary>
+/// <param name="dest">The string to copy the source string into</param>
+/// <param name="source">The source string</param>
+/// <param name="maxlength">The maximum length of the destination (optional=<b><c>sizeof dest</c></b>)</param>
+/// <seealso name="strcat"/>
+/// <returns>The length of the new destination string.</returns>
 stock strcopy(dest[], const source[], maxlength=sizeof dest)
 	return strcat((dest[0] = EOS, dest), source, maxlength);
 
+/// <summary>Extract a range of characters from a string.</summary>
+/// <param name="dest">The string to store the extracted characters in</param>
+/// <param name="source">The string from which to extract characters</param>
+/// <param name="start">The position of the first character</param>
+/// <param name="end">The position of the last character</param>
+/// <param name="maxlength">The length of the destination. (optional=<b><c>sizeof dest</c></b>)</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
+/// <returns>The number of characters stored in dest[].</returns>
 native strmid(dest[], const source[], start, end, maxlength=sizeof dest);
+
+/// <summary>Insert a string into another string.</summary>
+/// <param name="string">The string you want to insert substr in</param>
+/// <param name="substr">The string you want to insert into string</param>
+/// <param name="pos">The position to start inserting</param>
+/// <param name="maxlength">The maximum size to insert (optional=<b><c>sizeof string</c></b>)</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
 native bool: strins(string[], const substr[], pos, maxlength=sizeof string);
+
+/// <summary>Delete part of a string.</summary>
+/// <param name="string">The string to delete part of</param>
+/// <param name="start">The position of the first character to delete</param>
+/// <param name="end">The position of the last character to delete</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
 native bool: strdel(string[], start, end);
 
+
+/// <summary>Compares two strings to see if they are the same.</summary>
+/// <param name="string1">The first string to compare</param>
+/// <param name="string2">The second string to compare</param>
+/// <param name="ignorecase">When set to true, the case doesn't matter - HeLLo is the same as Hello. When false, they're not the same (optional=<b><c>0</c></b>)</param>
+/// <param name="length">When this length is set, the first x chars will be compared - doing "Hello" and "Hell No" with a length of 4 will say it's the same string (optional=<b><c>cellmax</c></b>)</param>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
+/// <seealso name="strequal"/>
+/// <remarks>This function returns <b><c>0</c></b> if either string is empty. Check for null strings with <c>isnull()</c>. If you do not, for example, people can login to anyone's account by simply entering a blank password. </remarks>
+/// <remarks>
+///   <code>
+///   #if !defined isnull<p/>
+///   &#9;#define isnull(%1) ((!(%1[0])) || (((%1[0]) == '\1') &amp;&amp; (!(%1[1]))))<p/>
+///   #endif
+///   </code>
+/// </remarks>
+/// <remarks>If you compare strings from a text file, you should take in to account the 'carriage return' and 'new line' special characters (\r \n), as they are included, when using fread.</remarks>
+/// <returns>
+///   <b><c>0</c></b> if strings match each other on given length;.<p/>
+///   <b><c>1</c></b> or <b><c>-1</c></b> if some character do not match: <c>string1[i] - string2[i]</c>.<p/>
+///   <b>difference in number of characters</b> if one string matches only part of another string.
+/// </returns>
 native strcmp(const string1[], const string2[], bool:ignorecase=false, length=cellmax);
+
+/// <summary>Search for a sub string in a string.</summary>
+/// <param name="string">The string you want to search in (haystack)</param>
+/// <param name="sub">The string you want to search for (needle)</param>
+/// <param name="ignorecase">When set to true, the case doesn't matter - HeLLo is the same as Hello. When false, they're not the same (optional=<b><c>0</c></b>)</param>
+/// <param name="pos">The offset to start searching from (optional=<b><c>0</c></b>)</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
+/// <returns>The number of characters before the sub string (the sub string's start position) or <b><c>-1</c></b> if it's not found.</returns>
 native strfind(const string[], const sub[], bool:ignorecase=false, pos=0);
 
+
+/// <summary>Convert a string to an integer.</summary>
+/// <param name="string">The string you want to convert to an integer</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strcat"/>
+/// <returns>The integer value of the string. <b><c>0</c></b> if the string is not numeric.</returns>
 native strval(const string[]);
+
+/// <summary>Convert an integer into a string.</summary>
+/// <param name="dest">The destination of the string</param>
+/// <param name="value">The value to convert to a string</param>
+/// <param name="pack">Whether to pack the destination (optional=<b><c>0</c></b>)</param>
+/// <seealso name="strval"/>
+/// <seealso name="strcmp"/>
+/// <remarks>Passing a high value to this function can cause the server to freeze/crash. Fixes are available. Below is a fix that can be put straight in to your script.</remarks>
+/// <remarks>
+///   <code>
+///     // valstr fix by Slice<p/>
+///     stock FIX_valstr(dest[], value, bool:pack = false)<p/>
+///     {<p/>
+///     &#9;// format can't handle cellmin properly<p/>
+///     &#9;static const cellmin_value[] = !"-2147483648";<p/>
+///     &#9;<p/>
+///     &#9;if (value == cellmin)<p/>
+///     &#9;&#9;pack &amp;&amp; strpack(dest, cellmin_value, 12) || strunpack(dest, cellmin_value, 12);<p/>
+///     &#9;else<p/>
+///     &#9;&#9;format(dest, 12, "%d", value), pack &amp;&amp; strpack(dest, dest, 12);<p/>
+///     }<p/>
+///     #define valstr FIX_valstr
+///   </code>
+/// </remarks>
 native valstr(dest[], value, bool:pack=false);
+
+/// <summary>Checks if the given string is packed.</summary>
+/// <param name="string">The string to check</param>
+/// <returns><b><c>true</c></b> if the string is packed, <b><c>false</c></b> if it's unpacked.</returns>
 native bool: ispacked(const string[]);
 
 // Don't define "format" twice.
@@ -34,9 +233,59 @@ native bool: ispacked(const string[]);
 	#define strformat(%0,%1,%2,%3) format(%0,%1,%3)
 #endif
 
+
+/// <summary>Decode an UU-encoded stream.</summary>
+/// <param name="dest">The array that will hold the decoded byte array.</param>
+/// <param name="source">The UU-encoded source string</param>
+/// <param name="maxlength">If the length of dest would exceed maxlength cells, the result is truncated to maxlength cells. Note that several bytes fit in each cell. (optional=<b><c>sizeof dest</c></b>)</param>
+/// <remarks>Since the UU-encoding scheme is used for binary data, the decoded data is always "packed". The data is unlikely to be a string (the zero-terminator may not be present, or it may be in the middle of the data).</remarks>
+/// <remarks>A buffer may be decoded "in-place"; the destination size is always smaller than the source size. Endian issues (for multi-byte values in the data stream) are not handled.</remarks>
+/// <remarks>Binary data is encoded in chunks of <b><c>45</c></b> bytes. To assemble these chunks into a complete stream, function <a href="#memcpy">memcpy</a> allows you to concatenate buffers at byte-aligned boundaries.</remarks>
+/// <seealso name="memcpy"/>
+/// <seealso name="uuencode"/>
+/// <returns>The number of bytes decoded and stored in dest.</returns>
 native uudecode(dest[], const source[], maxlength=sizeof dest);
+
+/// <summary>Encode an UU-encoded stream.</summary>
+/// <param name="dest">The array that will hold the encoded string.</param>
+/// <param name="source">The UU-encoded byte array.</param>
+/// <param name="numbytes">The number of bytes (in the source array) to encode. This should not exceed <b><c>45</c></b>.</param>
+/// <param name="maxlength">If the length of dest would exceed maxlength cells, the result is truncated to maxlength cells. Note that several bytes fit in each cell. (optional=<b><c>sizeof dest</c></b>)</param>
+/// <seealso name="memcpy"/>
+/// <seealso name="uudecode"/>
+/// <remarks>This function always creates a packed string. The string has a newline character at the end.</remarks>
+/// <remarks>Binary data is encoded in chunks of <b><c>45</c></b> bytes. To extract <b><c>45</c></b> bytes from an array with data, possibly from a byte-aligned address, you can use the function <a href="#memcpy">memcpy</a>.</remarks>
+/// <remarks>A buffer may be encoded "in-place" if the destination buffer is large enough. Endian issues (for multi-byte values in the data stream) are not handled.</remarks>
+/// <returns>The number of characters encoded, excluding the zero string terminator; if the dest buffer is too small, not all bytes are stored.</returns>
 native uuencode(dest[], const source[], numbytes, maxlength=sizeof dest);
+
+/// <summary>Copy bytes from one location to another.</summary>
+/// <param name="dest">An array into which the bytes from source are copied in</param>
+/// <param name="source">The source array</param>
+/// <param name="index">The start index in bytes in the destination array where the data should be copied to (optional=<b><c>0</c></b>)</param>
+/// <param name="numbytes">The number of bytes (not cells) to copy</param>
+/// <param name="maxlength">The maximum number of cells that fit in the destination buffer (optional=<b><c>sizeof dest</c></b>)</param>
+/// <seealso name="strcmp"/>
+/// <seealso name="strfind"/>
+/// <seealso name="strtok"/>
+/// <seealso name="strdel"/>
+/// <seealso name="strins"/>
+/// <seealso name="strlen"/>
+/// <seealso name="strmid"/>
+/// <seealso name="strpack"/>
+/// <seealso name="strval"/>
+/// <seealso name="strcat"/>
+/// <returns><b><c>true</c></b> on success, <b><c>false</c></b> on failure.</returns>
 native memcpy(dest[], const source[], index=0, numbytes, maxlength=sizeof dest);
 
+/// <summary>Compares two strings to see if they are the same.</summary>
+/// <param name="string1">The first string to compare</param>
+/// <param name="string2">The second string to compare</param>
+/// <param name="ignorecase">When set to true, the case doesn't matter - HeLLo is the same as Hello. When false, they're not the same (optional=<b><c>0</c></b>)</param>
+/// <param name="length">When this length is set, the first x chars will be compared - doing "Hello" and "Hell No" with a length of 4 will say it's the same string (optional=<b><c>cellmax</c></b>)</param>
+/// <seealso name="strcmp"/>
+/// <remarks>This is a conveniece function that depends on <a href=#strcmp>strcmp</a>.</remarks>
+/// <returns><b><c>true</c></b> if the strings match each other on given length, <b><c>false</c></b> otherwise.</returns>
+/// </returns>
 stock bool: strequal(const string1[], const string2[], bool:ignorecase=false, length=cellmax)
 	return strcmp(string1, string2, ignorecase, length) == 0;

--- a/time.inc
+++ b/time.inc
@@ -9,6 +9,23 @@
 #define _time_included
 #pragma library Time
 
+/// <summary>Get the current server time.</summary>
+/// <param name="hour">The variable to store the hour in, passed by reference (optional=<b><c>0</c></b>)</param>
+/// <param name="minute">The variable to store the minute in, passed by reference (optional=<b><c>0</c></b>)</param>
+/// <param name="second">The variable to store the seconds in, passed by reference (optional=<b><c>0</c></b>)</param>
+/// <seealso name="getdate"/>
+/// <returns>The function itself returns a Unix Timestamp.</returns>
 native gettime(&hour=0, &minute=0, &second=0);
+
+/// <summary>Get the current server date.</summary>
+/// <param name="year">The variable to store the year in, passed by reference (optional=<b><c>0</c></b>)</param>
+/// <param name="month">The variable to store the month in, passed by reference (optional=<b><c>0</c></b>)</param>
+/// <param name="day">The variable to store the day in, passed by reference (optional=<b><c>0</c></b>)</param>
+/// <seealso name="gettime"/>
+/// <returns>The number of days since the start of the year.</returns>
 native getdate(&year=0, &month=0, &day=0);
+
+/// <summary>This function can be used as a replacement for <a href="#GetTickCount">GetTickCount</a>, as it returns the number of milliseconds since the start-up of the server.</summary>
+/// <param name="granularity">Upon return, this value contains the number of ticks that the internal system time will tick per second. This value therefore indicates the accuracy of the return value of this function (optional=<b><c>0</c></b>)</param>
+/// <returns>The number of milliseconds since start-up of the system. For a 32-bit cell, this count overflows after approximately 24 days of continuous operation.</returns>
 native tickcount(&granularity=0);


### PR DESCRIPTION
Adds pawndoc to the functions, coming from either sa-mp wiki or official PDFs (see [basdon/documented-samp-pawn-api](https://github.com/basdon/documented-samp-pawn-api)).

Notes:
* datagram.inc: all the functions have a remark specific for SA:MP saying that these don't work on the current SA:MP version. I've left it in there because at the end this is to be used with sampctl, even if this is supposed to contain only non-samp stuff.
* the documentation also uses `<b>` and `<a>` tags, which will not work with the default XSLT file that comes with pawn. I've left them in there because they are useful if customized XSLT files are used (see [yugecin/pawndocimproved](https://github.com/yugecin/pawndocimproved)), and it will not cause troubles if the default is used.