### PR TITLE
file.inc: fseek doesn't return anything useful

### DIFF
--- a/file.inc
+++ b/file.inc
@@ -128,7 +128,6 @@ native fblockread(File: handle, buffer[], size = sizeof buffer);
 ///     <li><b><c>seek_end</c></b> - set the file position relative to the end of the file (parameter position must be zero or negative).</li>
 ///   </ul>
 /// </remarks>
-/// <returns>The new position; relative to the start of the file.</returns>
 native fseek(File: handle, position = 0, seek_whence: whence = seek_start);
 
 /// <summary>Returns the length of a file.</summary>


### PR DESCRIPTION
`fseek` was changed to use the C `fseek` function instead of `lseek`, which does report the position. `fseek` should return 0 on success and other values on failure, but at least on Windows, it seems to report success even for invalid combinations of arguments.