### PR TITLE
Fix the description and the declaration of fexist()

### DIFF
--- a/file.inc
+++ b/file.inc
@@ -137,9 +137,9 @@ native fseek(File: handle, position = 0, seek_whence: whence = seek_start);
 native flength(File: handle);
 
 /// <summary>Checks if a specific file exists in the <b><c>/scriptfiles</c></b> directory.</summary>
-/// <param name="pattern">The name of the file, optionally containing wild-cards characters</param>
-/// <returns>The number of files that match the pattern.</returns>
-native fexist(const pattern[]);
+/// <param name="name">The name of the file</param>
+/// <returns>1 if the file exists, 0 otherwise.</returns>
+native fexist(const name[]);
 
 /// <summary>Find a filename matching a pattern.</summary>
 /// <param name="name">The string to hold the result in, returned as a packed string</param>


### PR DESCRIPTION
Function `fexist` doesn't support search patterns as this feature was added somewhere between Pawn 3.1 and 3.2 and the server actually uses Pawn 3.0 (why `fexist` is defined in `file.inc` as in Pawn 3.2 while the server uses 3.0 is another question).

BTW, `fmatch` doesn't work for the same reason: the server uses 3.0, but the function was actually added in a later version of Pawn and doesn't exist in 3.0.

Another thing that could be done here is to add a `bool:` tag to `fexist` (as it originally was in Pawn 3.0), but this could introduce new warnings from the compiler (tag mismatch).