### PR TITLE
More SA:MP-esque formatting.

### DIFF
--- a/console.inc
+++ b/console.inc
@@ -4,7 +4,7 @@
  * This file is provided as is (no warranties).
  */
 #if defined _console_included
-  #endinput
+	#endinput
 #endif
 #define _console_included
 #pragma library Console

--- a/core.inc
+++ b/core.inc
@@ -4,7 +4,7 @@
  * This file is provided as is (no warranties).
  */
 #if defined _core_included
-  #endinput
+	#endinput
 #endif
 #define _core_included
 #pragma library Core

--- a/datagram.inc
+++ b/datagram.inc
@@ -4,7 +4,7 @@
  * This file is provided as is (no warranties).
  */
 #if defined _datagram_included
-  #endinput
+	#endinput
 #endif
 #define _datagram_included
 #pragma library DGram

--- a/file.inc
+++ b/file.inc
@@ -4,25 +4,25 @@
  * This file is provided as is (no warranties).
  */
 #if defined _file_included
-  #endinput
+	#endinput
 #endif
 #define _file_included
 #pragma library File
 
 enum filemode
-    {
-    io_read,            /* file must exist */
-    io_write,           /* creates a new file */
-    io_readwrite,       /* opens an existing file, or creates a new file */
-    io_append,          /* appends to file (write-only) */
-    }
+{
+	io_read,            /* file must exist */
+	io_write,           /* creates a new file */
+	io_readwrite,       /* opens an existing file, or creates a new file */
+	io_append,          /* appends to file (write-only) */
+}
 
 enum seek_whence
-    {
-    seek_start,
-    seek_current,
-    seek_end,
-    }
+{
+	seek_start,
+	seek_current,
+	seek_end,
+}
 
 const EOF = -1;
 

--- a/float.inc
+++ b/float.inc
@@ -8,23 +8,26 @@
  * This file is provided as is (no warranties).
  */
 #if defined _Float_included
-  #endinput
+	#endinput
 #endif
 #define _Float_included
 #pragma library Float
 
 /* Different methods of rounding */
-enum floatround_method {
-  floatround_round,
-  floatround_floor,
-  floatround_ceil,
-  floatround_tozero,
-  floatround_unbiased
+enum floatround_method
+{
+	floatround_round,
+	floatround_floor,
+	floatround_ceil,
+	floatround_tozero,
+	floatround_unbiased
 }
-enum anglemode {
-  radian,
-  degrees,
-  grades
+
+enum anglemode
+{
+	radian,
+	degrees,
+	grades
 }
 
 /// <summary>Converts an integer into a float.</summary>
@@ -201,82 +204,82 @@ native Float:operator-(Float:oper1, Float:oper2) = floatsub;
 native Float:operator=(oper) = float;
 
 stock Float:operator++(Float:oper)
-    return oper+1.0;
+	return oper+1.0;
 
 stock Float:operator--(Float:oper)
-    return oper-1.0;
+	return oper-1.0;
 
 stock Float:operator-(Float:oper)
-    return oper^Float:cellmin;                  /* IEEE values are sign/magnitude */
+	return oper^Float:cellmin;                  /* IEEE values are sign/magnitude */
 
 stock Float:operator*(Float:oper1, oper2)
-    return floatmul(oper1, float(oper2));       /* "*" is commutative */
+	return floatmul(oper1, float(oper2));       /* "*" is commutative */
 
 stock Float:operator/(Float:oper1, oper2)
-    return floatdiv(oper1, float(oper2));
+	return floatdiv(oper1, float(oper2));
 
 stock Float:operator/(oper1, Float:oper2)
-    return floatdiv(float(oper1), oper2);
+	return floatdiv(float(oper1), oper2);
 
 stock Float:operator+(Float:oper1, oper2)
-    return floatadd(oper1, float(oper2));       /* "+" is commutative */
+	return floatadd(oper1, float(oper2));       /* "+" is commutative */
 
 stock Float:operator-(Float:oper1, oper2)
-    return floatsub(oper1, float(oper2));
+	return floatsub(oper1, float(oper2));
 
 stock Float:operator-(oper1, Float:oper2)
-    return floatsub(float(oper1), oper2);
+	return floatsub(float(oper1), oper2);
 
 stock bool:operator==(Float:oper1, Float:oper2)
-    return floatcmp(oper1, oper2) == 0;
+	return floatcmp(oper1, oper2) == 0;
 
 stock bool:operator==(Float:oper1, oper2)
-    return floatcmp(oper1, float(oper2)) == 0;  /* "==" is commutative */
+	return floatcmp(oper1, float(oper2)) == 0;  /* "==" is commutative */
 
 stock bool:operator!=(Float:oper1, Float:oper2)
-    return floatcmp(oper1, oper2) != 0;
+	return floatcmp(oper1, oper2) != 0;
 
 stock bool:operator!=(Float:oper1, oper2)
-    return floatcmp(oper1, float(oper2)) != 0;  /* "!=" is commutative */
+	return floatcmp(oper1, float(oper2)) != 0;  /* "!=" is commutative */
 
 stock bool:operator>(Float:oper1, Float:oper2)
-    return floatcmp(oper1, oper2) > 0;
+	return floatcmp(oper1, oper2) > 0;
 
 stock bool:operator>(Float:oper1, oper2)
-    return floatcmp(oper1, float(oper2)) > 0;
+	return floatcmp(oper1, float(oper2)) > 0;
 
 stock bool:operator>(oper1, Float:oper2)
-    return floatcmp(float(oper1), oper2) > 0;
+	return floatcmp(float(oper1), oper2) > 0;
 
 stock bool:operator>=(Float:oper1, Float:oper2)
-    return floatcmp(oper1, oper2) >= 0;
+	return floatcmp(oper1, oper2) >= 0;
 
 stock bool:operator>=(Float:oper1, oper2)
-    return floatcmp(oper1, float(oper2)) >= 0;
+	return floatcmp(oper1, float(oper2)) >= 0;
 
 stock bool:operator>=(oper1, Float:oper2)
-    return floatcmp(float(oper1), oper2) >= 0;
+	return floatcmp(float(oper1), oper2) >= 0;
 
 stock bool:operator<(Float:oper1, Float:oper2)
-    return floatcmp(oper1, oper2) < 0;
+	return floatcmp(oper1, oper2) < 0;
 
 stock bool:operator<(Float:oper1, oper2)
-    return floatcmp(oper1, float(oper2)) < 0;
+	return floatcmp(oper1, float(oper2)) < 0;
 
 stock bool:operator<(oper1, Float:oper2)
-    return floatcmp(float(oper1), oper2) < 0;
+	return floatcmp(float(oper1), oper2) < 0;
 
 stock bool:operator<=(Float:oper1, Float:oper2)
-    return floatcmp(oper1, oper2) <= 0;
+	return floatcmp(oper1, oper2) <= 0;
 
 stock bool:operator<=(Float:oper1, oper2)
-    return floatcmp(oper1, float(oper2)) <= 0;
+	return floatcmp(oper1, float(oper2)) <= 0;
 
 stock bool:operator<=(oper1, Float:oper2)
-    return floatcmp(float(oper1), oper2) <= 0;
+	return floatcmp(float(oper1), oper2) <= 0;
 
 stock bool:operator!(Float:oper)
-    return (_:oper & cellmax) == 0;
+	return (_:oper & cellmax) == 0;
 
 /* forbidden operations */
 forward operator%(Float:oper1, Float:oper2);

--- a/string.inc
+++ b/string.inc
@@ -228,10 +228,31 @@ native bool: ispacked(const string[]);
 
 native strformat__(dest[], size=sizeof dest, const format[], {Float,_}:...) = format;
 /*
-native strformat(dest[], size=sizeof dest, bool:pack, const format[], {Float,_}:...);
+native strformat(dest[], size=sizeof dest, bool:pack=true, const format[], {Fixed,Float,_}:...);
 */
-// This is a macro not a stock because forwarding all variable parameters is not easy.
 #define strformat(%0,%1,%2,%3) strformat__(%0,%1,%3)
+// This is a macro not a stock because forwarding all variable parameters is not easy.  But would
+// look something like this, if there wasn't a bug with `SYSREQ.C` and otherwise unused natives:
+//stock strformat(dest[], size=sizeof dest, bool:pack=true, const format[], {Float,_}:...)
+//{
+//	static ret;
+//	#emit LOAD.S.pri       16
+//	#emit LOAD.S.pri       20
+//	#emit POP.alt
+//	#emit SCTRL 5
+//	#emit POP.pri
+//	#emit STOR.pri         ret
+//	#emit POP.pri
+//	#emit ADD.C            0xFFFFFFFC
+//	#emit POP.alt
+//	#emit SWAP.alt
+//	#emit PUSH.pri
+//	#emit SYSREQ.C         format
+//	#emit PUSH ret
+//	#emit LCTRL            5
+//	#emit PUSH.pri
+//	#emit RETN
+//}
 
 
 /// <summary>Decode an UU-encoded stream.</summary>

--- a/string.inc
+++ b/string.inc
@@ -226,12 +226,12 @@ native valstr(dest[], value, bool:pack=false);
 /// <returns><b><c>true</c></b> if the string is packed, <b><c>false</c></b> if it's unpacked.</returns>
 native bool: ispacked(const string[]);
 
-// Don't define "format" twice.
-#tryinclude <a_samp>
-#if !defined _samp_included
-	native format(dest[], size=sizeof dest, const format[], {Float,_}:...);
-	#define strformat(%0,%1,%2,%3) format(%0,%1,%3)
-#endif
+native strformat__(dest[], size=sizeof dest, const format[], {Float,_}:...) = format;
+/*
+native strformat(dest[], size=sizeof dest, bool:pack, const format[], {Float,_}:...);
+*/
+// This is a macro not a stock because forwarding all variable parameters is not easy.
+#define strformat(%0,%1,%2,%3) strformat__(%0,%1,%3)
 
 
 /// <summary>Decode an UU-encoded stream.</summary>

--- a/string.inc
+++ b/string.inc
@@ -4,7 +4,7 @@
  * This file is provided as is (no warranties).
  */
 #if defined _string_included
-  #endinput
+	#endinput
 #endif
 #define _string_included
 #pragma library String

--- a/time.inc
+++ b/time.inc
@@ -4,7 +4,7 @@
  * This file is provided as is (no warranties).
  */
 #if defined _time_included
-  #endinput
+	#endinput
 #endif
 #define _time_included
 #pragma library Time


### PR DESCRIPTION
After the discussion here: https://github.com/Southclaws/sampctl/issues/314 I realised that while the includes in sampctl/samp-stdlib are nice and consistently in line with established SA:MP styles, these ones weren't.  In fact, these weren't even in line with each other.  Some places used tabs, some 4 spaces, some 2 spaces.  Some places used K&R, some Allman, some indented the braces as well.

Now they are all the same and match the styling in the SA:MP includes.

I also added an alternative fix for the `format` collision, but I did that a while ago.