### PR TITLE
`fgetchar` doesn't have `value` at all.

### DIFF
--- a/file.inc
+++ b/file.inc
@@ -94,11 +94,10 @@ native bool:fputchar(File: handle, value, bool: utf8 = true);
 
 /// <summary>Reads a single character from a file.</summary>
 /// <param name="handle">The file handle to use; returned by <a href="#fopen">fopen</a></param>
-/// <param name="value">This parameter has no use, just keep it "0"</param>
 /// <param name="utf8">If true, read a character as UTF-8, otherwise as extended ASCII (optional=<b><c>true</c></b>)</param>
 /// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#fopen">fopen</a> or <a href="#ftemp">ftemp</a>.</remarks>
 /// <returns>If succeed, it returns the extended ASCII or UTF-8 value of the character at the current position in the file, otherwise EOF (end of file).</returns>
-native fgetchar(File: handle, value, bool: utf8 = true);
+native fgetchar(File: handle, bool: utf8 = true);
 
 /// <summary>Write data to a file in binary format, while ignoring line brakes and encoding.</summary>
 /// <param name="handle">The File handle to use, opened by fopen()</param>


### PR DESCRIPTION
The native source:

```c
/* fgetchar(File: handle, bool:utf8 = true) */
static cell AMX_NATIVE_CALL n_fgetchar(AMX *amx, const cell *params)
{
  cell str[2];
  size_t result;

  UNUSED_PARAM(amx);
  if (params[2]) {
    result=fgets_cell((FILE*)params[1],str,2,1);
  } else {
    str[0]=fgetc((FILE*)params[1]);
    result= (str[0]!=EOF);
  } /* if */
  assert(result==0 || result==1);
  if (result==0)
    return EOF;
  else
    return str[0];
}
```

Literally doesn't exist - not just "useless".